### PR TITLE
fix: replace vite preview with stable Node production server

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,8 +20,7 @@ ENV NODE_ENV=production
 COPY --from=deps /app/node_modules ./node_modules
 COPY --from=builder /app/dist ./dist
 COPY --from=builder /app/package.json ./package.json
-COPY --from=builder /app/vite.config.ts ./vite.config.ts
-COPY --from=builder /app/src ./src
+COPY --from=builder /app/server.js ./server.js
 
 RUN mkdir -p /app/data
 

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "dev": "vite dev",
     "build": "vite build",
-    "start": "vite preview --host 0.0.0.0 --port 3000",
+    "start": "node server.js",
     "seed": "tsx src/db/seed.ts",
     "typecheck": "tsc --noEmit",
     "format": "prettier --write .",

--- a/server.js
+++ b/server.js
@@ -1,0 +1,141 @@
+import { createServer } from "node:http";
+import { readFile, stat } from "node:fs/promises";
+import { join, extname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = fileURLToPath(new URL(".", import.meta.url));
+const clientDir = join(__dirname, "dist", "client");
+
+const MIME_TYPES = {
+  ".html": "text/html",
+  ".js": "application/javascript",
+  ".css": "text/css",
+  ".json": "application/json",
+  ".png": "image/png",
+  ".jpg": "image/jpeg",
+  ".jpeg": "image/jpeg",
+  ".gif": "image/gif",
+  ".svg": "image/svg+xml",
+  ".ico": "image/x-icon",
+  ".woff": "font/woff",
+  ".woff2": "font/woff2",
+  ".ttf": "font/ttf",
+  ".pdf": "application/pdf",
+  ".webp": "image/webp",
+  ".avif": "image/avif",
+  ".txt": "text/plain",
+  ".xml": "application/xml",
+  ".webmanifest": "application/manifest+json",
+};
+
+// Import the TanStack Start server handler
+const { default: server } = await import("./dist/server/server.js");
+
+async function tryServeStatic(req, res) {
+  const url = new URL(req.url, `http://${req.headers.host || "localhost"}`);
+  const filePath = join(clientDir, url.pathname);
+
+  // Prevent path traversal
+  if (!filePath.startsWith(clientDir)) return false;
+
+  try {
+    const fileStat = await stat(filePath);
+    if (!fileStat.isFile()) return false;
+
+    const ext = extname(filePath).toLowerCase();
+    const contentType = MIME_TYPES[ext] || "application/octet-stream";
+    const content = await readFile(filePath);
+
+    // Cache hashed assets aggressively, everything else short-cache
+    const isHashed = url.pathname.startsWith("/assets/");
+    const cacheControl = isHashed
+      ? "public, max-age=31536000, immutable"
+      : "public, max-age=3600";
+
+    res.writeHead(200, {
+      "Content-Type": contentType,
+      "Content-Length": content.length,
+      "Cache-Control": cacheControl,
+    });
+    res.end(content);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function nodeReqToWebRequest(req) {
+  const protocol = req.headers["x-forwarded-proto"] || "http";
+  const host = req.headers["x-forwarded-host"] || req.headers.host || "localhost";
+  const url = `${protocol}://${host}${req.url}`;
+
+  const headers = new Headers();
+  for (const [key, value] of Object.entries(req.headers)) {
+    if (value === undefined) continue;
+    if (Array.isArray(value)) {
+      for (const v of value) headers.append(key, v);
+    } else {
+      headers.set(key, value);
+    }
+  }
+
+  const method = req.method || "GET";
+  const hasBody = method !== "GET" && method !== "HEAD";
+
+  return new Request(url, {
+    method,
+    headers,
+    body: hasBody ? req : undefined,
+    // @ts-ignore - Node ReadableStream as body
+    duplex: hasBody ? "half" : undefined,
+  });
+}
+
+async function webResponseToNode(webRes, res) {
+  res.writeHead(webRes.status, Object.fromEntries(webRes.headers.entries()));
+
+  if (!webRes.body) {
+    res.end();
+    return;
+  }
+
+  const reader = webRes.body.getReader();
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      res.write(value);
+    }
+  } finally {
+    reader.releaseLock();
+    res.end();
+  }
+}
+
+const httpServer = createServer(async (req, res) => {
+  try {
+    // Try static files first
+    if (req.method === "GET" || req.method === "HEAD") {
+      const served = await tryServeStatic(req, res);
+      if (served) return;
+    }
+
+    // Fall through to SSR
+    const webReq = nodeReqToWebRequest(req);
+    const webRes = await server.fetch(webReq);
+    await webResponseToNode(webRes, res);
+  } catch (err) {
+    console.error("Request error:", err);
+    if (!res.headersSent) {
+      res.writeHead(500, { "Content-Type": "text/plain" });
+      res.end("Internal Server Error");
+    }
+  }
+});
+
+const port = parseInt(process.env.PORT || "3000", 10);
+const host = process.env.HOST || "0.0.0.0";
+
+httpServer.listen(port, host, () => {
+  console.log(`Production server running at http://${host}:${port}`);
+});


### PR DESCRIPTION
## Problem

`vite preview` SSR was corrupting routing after ~1-2 hours in production, serving random 307 redirects to nonsense paths (`/.git/info`, `/wp-includes/block-supports`, `/backup`). Had to restart the container 3 times today.

## Solution

Replace `vite preview` with a direct Node HTTP server (`server.js`) that:
- Serves static assets from `dist/client/` with proper cache headers (immutable for hashed assets)
- Passes all other requests through TanStack Start's `fetch()` handler for SSR
- No vite runtime in production — just Node + the built server bundle
- Smaller Docker image: removes `vite.config.ts` and `src/` from production layer

## Testing

Tested locally — all routes (/, /about, /writing, /admin) return 200. Static assets (resume.pdf, JS/CSS) serve correctly with proper MIME types.