### PR TITLE
chore: migrations run on deploy

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,6 @@ The full site runs as one Cloudflare Worker:
 
 ```bash
 pnpm exec wrangler login
-pnpm run db:migrate
 pnpm exec wrangler secret put SPOTIFY_CLIENT_ID
 pnpm exec wrangler secret put SPOTIFY_CLIENT_SECRET
 pnpm exec wrangler secret put SPOTIFY_REFRESH_TOKEN
@@ -72,8 +71,11 @@ pnpm run deploy
 ```
 
 Create the Access application before deploying, or the CMS locks out.
-Deploys run from Cloudflare Workers Builds on push to `main`; the commands
-above are for the first-time setup and for deploying by hand.
+
+Deploys run from Cloudflare Workers Builds on push to `main`. Its deploy
+command must be `pnpm run deploy`, which applies migrations before uploading
+so schema changes land before the code that needs them. Running
+`wrangler deploy` directly would skip that.
 
 To get the Spotify refresh token:
 

--- a/package.json
+++ b/package.json
@@ -10,9 +10,9 @@
     "test": "vitest run",
     "build": "tsc --noEmit && vite build && cp dist/client/index.html dist/client/404.html",
     "preview": "vite preview",
-    "deploy": "pnpm run build && wrangler deploy",
-    "db:migrate:local": "wrangler d1 migrations apply portfolio-cms --local",
-    "db:migrate": "wrangler d1 migrations apply portfolio-cms --remote"
+    "deploy": "pnpm run build && pnpm run db:migrate && wrangler deploy",
+    "db:migrate:local": "wrangler d1 migrations apply DB --local",
+    "db:migrate": "wrangler d1 migrations apply DB --remote"
   },
   "dependencies": {
     "@tiptap/react": "^3.0.0",


### PR DESCRIPTION
Applies D1 migrations as part of deploy so schema changes land before the code needing them.