### PR TITLE
refactor: editor takes the reader's measure

### DIFF
--- a/src/admin/Admin.tsx
+++ b/src/admin/Admin.tsx
@@ -60,16 +60,15 @@ export function Admin() {
         </div>
       </aside>
 
+      {/* Each page sets its own measure: a list wants width, an article does not. */}
       <main className="min-w-0 flex-1">
-        <div className="mx-auto max-w-4xl px-8 py-10">
-          <Routes>
-            <Route index element={<Navigate to="posts" replace />} />
-            <Route path="posts" element={<PostsList />} />
-            <Route path="posts/:slug" element={<PostEdit />} />
-            <Route path="projects" element={<Projects />} />
-            <Route path="experiences" element={<Experiences />} />
-          </Routes>
-        </div>
+        <Routes>
+          <Route index element={<Navigate to="posts" replace />} />
+          <Route path="posts" element={<PostsList />} />
+          <Route path="posts/:slug" element={<PostEdit />} />
+          <Route path="projects" element={<Projects />} />
+          <Route path="experiences" element={<Experiences />} />
+        </Routes>
       </main>
     </div>
   )

--- a/src/admin/components/ui.tsx
+++ b/src/admin/components/ui.tsx
@@ -71,6 +71,11 @@ export function Status({ status }: { status: "draft" | "published" }) {
   )
 }
 
+/** The standard admin measure. The post editor opts out and uses the article's. */
+export function Page({ children }: { children: ReactNode }) {
+  return <div className="mx-auto max-w-4xl space-y-6 px-8 py-10">{children}</div>
+}
+
 export function PageHeader({
   title,
   description,

--- a/src/admin/pages/Experiences.tsx
+++ b/src/admin/pages/Experiences.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useState } from "react"
 import { api, errorMessage } from "../api"
-import { Alert, Button, Card, Field, inputClass, PageHeader } from "../components/ui"
+import { Alert, Button, Card, Field, inputClass, Page, PageHeader } from "../components/ui"
 
 type Experience = Awaited<ReturnType<typeof api.admin.experiences.list.query>>[number]
 
@@ -77,7 +77,7 @@ export function Experiences() {
   }
 
   return (
-    <div className="space-y-6">
+    <Page>
       <PageHeader
         title="Experiences"
         description="Roles listed on the site, in the order they appear."
@@ -206,6 +206,6 @@ export function Experiences() {
           </li>
         ))}
       </ul>
-    </div>
+    </Page>
   )
 }

--- a/src/admin/pages/PostEdit.tsx
+++ b/src/admin/pages/PostEdit.tsx
@@ -196,8 +196,9 @@ export function PostEdit() {
   const published = post.status === "published"
 
   return (
-    <div className="pb-24">
-      <header className="flex items-center justify-between gap-4">
+    <div>
+      {/* Sticky: on a long post the publish control should never scroll away. */}
+      <header className="sticky top-0 z-20 flex items-center justify-between gap-4 border-b border-border bg-background/85 px-8 py-3 backdrop-blur">
         <Link
           to="/admin/posts"
           className="-ml-2.5 inline-flex h-9 items-center gap-1.5 rounded-md px-2.5 text-sm text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
@@ -235,72 +236,79 @@ export function PostEdit() {
         </div>
       </header>
 
-      {error && (
-        <div className="mt-5">
-          <Alert message={error} />
-        </div>
-      )}
+      {/*
+        The same measure as the published article. A wider column here would
+        reflow every line on publish, which is the one thing a writing surface
+        built on the reader's stylesheet must not do.
+      */}
+      <div className="mx-auto max-w-2xl px-6 pb-32 pt-12">
+        {error && (
+          <div className="mb-8">
+            <Alert message={error} />
+          </div>
+        )}
 
-      <article className="mt-12">
-        <CoverImage
-          src={draft.coverImage}
-          uploading={uploadingCover}
-          onPick={pickCover}
-          onRemove={() => change({ coverImage: null })}
-        />
-
-        <AutoTextarea
-          ref={titleField}
-          value={draft.title}
-          onChange={title => change({ title })}
-          onEnter={() => summaryField.current?.focus()}
-          placeholder="Title"
-          className="editorial w-full resize-none bg-transparent text-4xl font-semibold leading-tight tracking-tight text-foreground outline-none placeholder:text-subtle-foreground"
-        />
-
-        <AutoTextarea
-          ref={summaryField}
-          value={draft.excerpt}
-          onChange={excerpt => change({ excerpt })}
-          onEnter={focusBody}
-          onBackspaceAtStart={() => focusEnd(titleField.current)}
-          placeholder="Add a summary"
-          className="editorial mt-4 w-full resize-none bg-transparent text-lg leading-relaxed text-muted-foreground outline-none placeholder:text-subtle-foreground"
-        />
-
-        <div className="mt-10">
-          <PostEditor
-            onReady={editor => (body.current = editor)}
-            initialContent={post.content}
-            onChange={content => change({ content })}
-            onError={setError}
-            onLeaveStart={() => focusEnd(summaryField.current)}
+        <article>
+          <CoverImage
+            src={draft.coverImage}
+            uploading={uploadingCover}
+            onPick={pickCover}
+            onRemove={() => change({ coverImage: null })}
           />
-        </div>
-      </article>
 
-      <footer className="mt-12 flex flex-wrap items-center justify-between gap-3 border-t border-border pt-5">
-        <div className="min-w-0 text-xs text-muted-foreground">
-          /writing/{slug}
-          {!post.publishedAt && slugify(draft.title) !== slug && (
-            <button
-              onClick={rename}
-              disabled={busy}
-              className="ml-3 text-foreground underline decoration-border underline-offset-4 transition-colors hover:decoration-foreground"
-            >
-              Use the title
-            </button>
-          )}
-          {post.publishedAt && <span className="ml-3">Fixed once published</span>}
-        </div>
-        <ConfirmButton
-          label="Delete"
-          confirmLabel="Delete permanently"
-          icon={Trash2}
-          onConfirm={remove}
-          disabled={busy}
-        />
-      </footer>
+          <AutoTextarea
+            ref={titleField}
+            value={draft.title}
+            onChange={title => change({ title })}
+            onEnter={() => summaryField.current?.focus()}
+            placeholder="Title"
+            className="editorial w-full resize-none bg-transparent text-4xl font-semibold leading-tight tracking-tight text-foreground outline-none placeholder:text-subtle-foreground"
+          />
+
+          <AutoTextarea
+            ref={summaryField}
+            value={draft.excerpt}
+            onChange={excerpt => change({ excerpt })}
+            onEnter={focusBody}
+            onBackspaceAtStart={() => focusEnd(titleField.current)}
+            placeholder="Add a summary"
+            className="editorial mt-4 w-full resize-none bg-transparent text-lg leading-relaxed text-muted-foreground outline-none placeholder:text-subtle-foreground"
+          />
+
+          <div className="mt-10">
+            <PostEditor
+              onReady={editor => (body.current = editor)}
+              initialContent={post.content}
+              onChange={content => change({ content })}
+              onError={setError}
+              onLeaveStart={() => focusEnd(summaryField.current)}
+            />
+          </div>
+        </article>
+
+        <footer className="mt-16 flex flex-wrap items-center justify-between gap-3 border-t border-border pt-5">
+          <div className="min-w-0 text-xs text-muted-foreground">
+            /writing/{slug}
+            {!post.publishedAt && slugify(draft.title) !== slug && (
+              <button
+                onClick={rename}
+                disabled={busy}
+                className="ml-3 text-foreground underline decoration-border underline-offset-4 transition-colors hover:decoration-foreground"
+              >
+                Use the title
+              </button>
+            )}
+            {post.publishedAt && <span className="ml-3">Fixed once published</span>}
+          </div>
+          <ConfirmButton
+            label="Delete"
+            confirmLabel="Delete permanently"
+            icon={Trash2}
+            onConfirm={remove}
+            disabled={busy}
+          />
+        </footer>
+      </div>
     </div>
   )
 }

--- a/src/admin/pages/PostsList.tsx
+++ b/src/admin/pages/PostsList.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from "react"
 import { Link, useNavigate } from "react-router-dom"
 import { PenLine, Plus } from "lucide-react"
 import { api, errorMessage, type RouterOutputs } from "../api"
-import { Alert, Button, Card, EmptyState, PageHeader, Status } from "../components/ui"
+import { Alert, Button, Card, EmptyState, Page, PageHeader, Status } from "../components/ui"
 
 type Post = RouterOutputs["admin"]["posts"]["list"][number]
 
@@ -45,7 +45,7 @@ export function PostsList() {
   )
 
   return (
-    <div className="space-y-6">
+    <Page>
       <PageHeader title="Posts" description={summarise(posts)} action={newPost} />
 
       {error && <Alert message={error} />}
@@ -95,7 +95,7 @@ export function PostsList() {
           ))}
         </Card>
       )}
-    </div>
+    </Page>
   )
 }
 

--- a/src/admin/pages/Projects.tsx
+++ b/src/admin/pages/Projects.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useState } from "react"
 import { api, errorMessage } from "../api"
-import { Alert, Button, Card, Field, inputClass, PageHeader } from "../components/ui"
+import { Alert, Button, Card, Field, inputClass, Page, PageHeader } from "../components/ui"
 
 type Project = Awaited<ReturnType<typeof api.admin.projects.list.query>>[number]
 
@@ -71,7 +71,7 @@ export function Projects() {
   }
 
   return (
-    <div className="space-y-6">
+    <Page>
       <PageHeader
         title="Projects"
         description="The work listed on the site, in the order it appears."
@@ -176,6 +176,6 @@ export function Projects() {
           </li>
         ))}
       </ul>
-    </div>
+    </Page>
   )
 }

--- a/src/editor/SelectionMenu.tsx
+++ b/src/editor/SelectionMenu.tsx
@@ -33,7 +33,9 @@ export function SelectionMenu({ editor }: { editor: Editor }) {
       shouldShow={({ editor, from, to }) =>
         from !== to && !editor.isActive("codeBlock") && !editor.isActive("image")
       }
-      options={{ placement: "top", offset: 8 }}
+      // Clear of the line by more than a line-height, flipping below when the
+      // selection is near the top, and shifted to stay inside the viewport.
+      options={{ placement: "top", offset: 12, flip: true, shift: true }}
       className={floatingPanel}
       onKeyDown={event => event.key === "Escape" && setEditingLink(false)}
     >

--- a/src/editor/controls.tsx
+++ b/src/editor/controls.tsx
@@ -36,5 +36,9 @@ export function ToolDivider() {
   return <div className="mx-1 my-1.5 w-px self-stretch bg-border" />
 }
 
+/**
+ * min-w keeps the panel from resizing when the link field replaces the button
+ * row, which would otherwise move the buttons out from under the pointer.
+ */
 export const floatingPanel =
-  "flex items-center rounded-xl border border-border bg-card p-1 shadow-xl shadow-black/40"
+  "flex min-w-[19rem] items-center rounded-lg border border-border bg-card p-1 shadow-lg shadow-black/50"


### PR DESCRIPTION
Matches the writing column to the published article, makes the header sticky, and stops the selection menu covering the text it acts on.