### PR TITLE
fix: give the site back its own visual language

### DIFF
--- a/src/admin/pages/PostEdit.tsx
+++ b/src/admin/pages/PostEdit.tsx
@@ -209,7 +209,7 @@ export function PostEdit() {
 
         <div className="flex items-center gap-3">
           {stats && stats.words > 0 && (
-            <span className="text-xs text-muted-foreground">
+            <span className="font-mono text-xs text-subtle-foreground">
               {stats.words} words · {stats.minutes} min
             </span>
           )}
@@ -287,7 +287,7 @@ export function PostEdit() {
         </article>
 
         <footer className="mt-16 flex flex-wrap items-center justify-between gap-3 border-t border-border pt-5">
-          <div className="min-w-0 text-xs text-muted-foreground">
+          <div className="min-w-0 font-mono text-xs text-subtle-foreground">
             /writing/{slug}
             {!post.publishedAt && slugify(draft.title) !== slug && (
               <button
@@ -337,7 +337,7 @@ function SaveIndicator({ state }: { state: SaveState }) {
   const label = { dirty: "Unsaved", saving: "Saving", failed: "Could not save" }[state]
   const tone = state === "failed" ? "text-destructive" : "text-muted-foreground"
 
-  return <span className={`text-xs ${tone}`}>{label}</span>
+  return <span className={`font-mono text-xs ${tone}`}>{label}</span>
 }
 
 function CoverImage({
@@ -382,7 +382,7 @@ function CoverImage({
         <button
           onClick={() => input.current?.click()}
           disabled={uploading}
-          className="flex items-center gap-2 text-xs text-muted-foreground transition-colors hover:text-foreground"
+          className="flex items-center gap-2 font-mono text-xs text-subtle-foreground transition-colors hover:text-foreground"
         >
           {uploading ? (
             <LoaderCircle size={14} className="animate-spin" />

--- a/src/admin/pages/PostsList.tsx
+++ b/src/admin/pages/PostsList.tsx
@@ -88,7 +88,7 @@ export function PostsList() {
                 )}
               </span>
 
-              <span className="shrink-0 text-xs tabular-nums text-subtle-foreground">
+              <span className="shrink-0 font-mono text-xs tabular-nums text-subtle-foreground">
                 {post.publishedAt ? formatDate(post.publishedAt) : formatDate(post.updatedAt)}
               </span>
             </Link>

--- a/src/index.css
+++ b/src/index.css
@@ -5,37 +5,45 @@
  * a surface token says where something sits, a foreground token says how
  * loudly it speaks. Components never reach for a raw palette value.
  *
- * The neutral ramp is true zinc rather than a tinted one, and there is no
- * decorative accent hue. Colour is reserved for meaning: destructive for
- * removal, success for a published post, ring for focus. Emphasis is carried
- * by weight, surface and space instead.
+ * The neutrals are a blue-tinted ink ramp at hue 265; the lone accent is a
+ * warm amber at hue 78, used for interaction.
+ *
+ * The site and the admin share this scale but not its emphasis. The site is a
+ * portfolio and spends the accent on every hover, so it has a voice. The admin
+ * is a tool, and leaves the accent to focus rings and links so nothing
+ * competes with the content being edited. They are meant to look like
+ * different places.
  */
 @theme {
   --font-sans: "Inter", ui-sans-serif, system-ui, sans-serif;
   --font-mono: "JetBrains Mono", ui-monospace, SFMono-Regular, Menlo, monospace;
 
   /* surfaces, darkest to lightest */
-  --color-background: oklch(0.141 0.005 285.823);
-  --color-card: oklch(0.21 0.006 285.885);
-  --color-muted: oklch(0.274 0.006 286.033);
+  --color-background: oklch(0.17 0.008 265);
+  --color-card: oklch(0.2 0.009 265);
+  --color-muted: oklch(0.24 0.01 265);
 
   /* text, loudest to quietest */
-  --color-foreground: oklch(0.985 0 0);
-  --color-muted-foreground: oklch(0.705 0.015 286.067);
-  --color-subtle-foreground: oklch(0.552 0.016 285.938);
+  --color-foreground: oklch(0.94 0.004 265);
+  --color-muted-foreground: oklch(0.73 0.01 265);
+  --color-subtle-foreground: oklch(0.54 0.012 265);
 
-  /* lines. Translucent so they sit correctly on any surface above. */
-  --color-border: oklch(1 0 0 / 10%);
-  --color-input: oklch(1 0 0 / 15%);
-  --color-ring: oklch(0.552 0.016 285.938);
+  /* lines */
+  --color-border: oklch(0.29 0.01 265);
+  --color-input: oklch(0.29 0.01 265);
+  --color-ring: oklch(0.8 0.125 78);
 
   /* inverted, for the one solid control on a screen */
-  --color-primary: oklch(0.985 0 0);
-  --color-primary-foreground: oklch(0.21 0.006 285.885);
+  --color-primary: oklch(0.94 0.004 265);
+  --color-primary-foreground: oklch(0.2 0.009 265);
 
-  /* meaning, never decoration */
-  --color-destructive: oklch(0.704 0.191 22.216);
-  --color-success: oklch(0.72 0.14 155);
+  /* Interaction, on the site. The admin leaves it to focus and links. */
+  --color-accent: oklch(0.8 0.125 78);
+  --color-accent-strong: oklch(0.87 0.13 80);
+
+  /* meaning */
+  --color-destructive: oklch(0.7 0.18 25);
+  --color-success: oklch(0.78 0.13 165);
 
   --radius-card: 0.625rem;
 }

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -173,7 +173,7 @@ export function Home() {
     <div className="mx-auto max-w-2xl px-6 py-28">
       {/* Header */}
       <header>
-        <p className="text-sm text-muted-foreground">New York, NY</p>
+        <p className="font-mono text-xs tracking-wide text-subtle-foreground">New York, NY</p>
         <h1 className="mt-3 text-4xl font-semibold tracking-tight text-foreground">
           David Oduneye
         </h1>

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -102,7 +102,7 @@ function OnRepeat() {
         href={track.url}
         target="_blank"
         rel="noopener noreferrer"
-        className="text-foreground underline decoration-border underline-offset-4 transition-colors hover:decoration-foreground"
+        className="text-muted-foreground transition-colors hover:text-accent"
       >
         {track.name}
       </a>{" "}
@@ -113,8 +113,13 @@ function OnRepeat() {
 
 function Section({ title, children }: { title: string; children: React.ReactNode }) {
   return (
-    <section className="mt-20">
-      <h2 className="mb-8 text-sm font-medium text-foreground">{title}</h2>
+    <section className="mt-24">
+      <div className="mb-10 flex items-baseline gap-3">
+        <h2 className="font-mono text-xs uppercase tracking-[0.25em] text-subtle-foreground">
+          {title}
+        </h2>
+        <div className="h-px flex-1 self-center bg-border" />
+      </div>
       {children}
     </section>
   )
@@ -140,7 +145,9 @@ function RecentWriting() {
           <li key={post.slug} className="border-b border-border last:border-b-0">
             <Link to={`/writing/${post.slug}`} className="group block py-6">
               <div className="flex items-baseline justify-between gap-4">
-                <h3 className="font-medium text-foreground">{post.title}</h3>
+                <h3 className="font-medium text-foreground transition-colors group-hover:text-accent">
+                  {post.title}
+                </h3>
                 <span className="shrink-0 font-mono text-xs text-subtle-foreground">
                   {post.publishedAt &&
                     new Date(post.publishedAt).toLocaleDateString("en-US", {
@@ -159,7 +166,7 @@ function RecentWriting() {
       {posts.length > 4 && (
         <Link
           to="/writing"
-          className="mt-6 inline-block font-mono text-xs text-subtle-foreground transition-colors hover:text-foreground"
+          className="mt-6 inline-block font-mono text-xs text-subtle-foreground transition-colors hover:text-accent"
         >
           All writing →
         </Link>
@@ -183,7 +190,7 @@ export function Home() {
             href="https://www.agency.inc"
             target="_blank"
             rel="noopener noreferrer"
-            className="text-foreground underline decoration-border underline-offset-4 transition-colors hover:decoration-foreground"
+            className="text-foreground transition-colors hover:text-accent"
           >
             Agency
           </a>
@@ -197,7 +204,7 @@ export function Home() {
               href={link.url}
               target={link.url.startsWith("http") ? "_blank" : undefined}
               rel="noopener noreferrer"
-              className="text-muted-foreground underline decoration-border underline-offset-4 transition-colors hover:text-foreground hover:decoration-foreground"
+              className="text-subtle-foreground underline decoration-border underline-offset-4 transition-colors hover:text-accent hover:decoration-accent"
             >
               {link.label}
             </a>
@@ -222,7 +229,7 @@ export function Home() {
                       href={job.orgUrl}
                       target="_blank"
                       rel="noopener noreferrer"
-                      className="transition-colors hover:text-foreground"
+                      className="transition-colors hover:text-accent"
                     >
                       {job.org}
                     </a>
@@ -244,9 +251,11 @@ export function Home() {
             const inner = (
               <>
                 <div className="flex items-baseline justify-between gap-4">
-                  <h3 className="font-medium text-foreground">{project.name}</h3>
+                  <h3 className="font-medium text-foreground transition-colors group-hover:text-accent">
+                    {project.name}
+                  </h3>
                   {project.url && (
-                    <span className="font-mono text-xs text-subtle-foreground transition-colors group-hover:text-foreground">
+                    <span className="font-mono text-xs text-subtle-foreground transition-colors group-hover:text-accent">
                       ↗
                     </span>
                   )}
@@ -290,7 +299,7 @@ export function Home() {
                 href={link.url}
                 target={link.url.startsWith("http") ? "_blank" : undefined}
                 rel="noopener noreferrer"
-                className="transition-colors hover:text-foreground"
+                className="transition-colors hover:text-accent"
               >
                 {link.label}
               </a>

--- a/src/pages/Post.tsx
+++ b/src/pages/Post.tsx
@@ -35,7 +35,7 @@ export function Post() {
         <h1 className="text-2xl font-semibold text-foreground">Not found</h1>
         <p className="mt-3 text-sm">
           That post does not exist, or it is not published.{" "}
-          <Link to="/writing" className="text-foreground hover:underline">
+          <Link to="/writing" className="text-accent hover:underline">
             See what is.
           </Link>
         </p>
@@ -76,7 +76,7 @@ export function Post() {
       <footer className="mt-20 border-t border-border pt-8">
         <Link
           to="/writing"
-          className="font-mono text-xs text-subtle-foreground transition-colors hover:text-foreground"
+          className="font-mono text-xs text-subtle-foreground transition-colors hover:text-accent"
         >
           ← All writing
         </Link>
@@ -90,7 +90,7 @@ function Shell({ children }: { children?: React.ReactNode }) {
     <div className="mx-auto max-w-2xl px-6 py-28">
       <Link
         to="/"
-        className="font-mono text-xs text-subtle-foreground transition-colors hover:text-foreground"
+        className="font-mono text-xs text-subtle-foreground transition-colors hover:text-accent"
       >
         ← David Oduneye
       </Link>

--- a/src/pages/Writing.tsx
+++ b/src/pages/Writing.tsx
@@ -22,7 +22,7 @@ export function Writing() {
     <div className="mx-auto max-w-2xl px-6 py-28">
       <Link
         to="/"
-        className="font-mono text-xs text-subtle-foreground transition-colors hover:text-foreground"
+        className="font-mono text-xs text-subtle-foreground transition-colors hover:text-accent"
       >
         ← David Oduneye
       </Link>
@@ -38,7 +38,7 @@ export function Writing() {
           <li key={post.slug}>
             <Link to={`/writing/${post.slug}`} className="group flex gap-6 py-8">
               <div className="min-w-0 flex-1">
-                <h2 className="font-medium text-foreground transition-colors group-hover:text-foreground">
+                <h2 className="font-medium text-foreground transition-colors group-hover:text-accent">
                   {post.title}
                 </h2>
                 {post.excerpt && <p className="mt-2 text-sm leading-relaxed">{post.excerpt}</p>}


### PR DESCRIPTION
Restores the blue-tinted ramp, the amber interaction colour and the section rule on the public site, and keeps the admin neutral so the two read as different places.