### PR TITLE
chore: remove comments

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,7 +4,6 @@ import { Home } from "./pages/Home"
 import { Writing } from "./pages/Writing"
 
 const Admin = lazy(() => import("./admin/Admin").then(m => ({ default: m.Admin })))
-// The renderer and its extensions are only needed once a post is opened.
 const Post = lazy(() => import("./pages/Post").then(m => ({ default: m.Post })))
 
 export function App() {

--- a/src/admin/Admin.tsx
+++ b/src/admin/Admin.tsx
@@ -63,7 +63,6 @@ export function Admin() {
         </div>
       </aside>
 
-      {/* Each page sets its own measure: a list wants width, an article does not. */}
       <main className="min-w-0 flex-1">
         {error && (
           <div className="px-8 pt-6">

--- a/src/admin/api.ts
+++ b/src/admin/api.ts
@@ -13,8 +13,6 @@ const reauthenticateOnExpiry: TRPCLink<AppRouter> =
       next(op).subscribe({
         next: value => observer.next(value),
         error: error => {
-          // No observer.error: the document is being replaced, and reporting the
-          // failure would flash an error over a page that is already leaving.
           if (error.data?.code === "UNAUTHORIZED") return window.location.reload()
           observer.error(error)
         },
@@ -27,8 +25,6 @@ export const api = createTRPCClient<AppRouter>({
 })
 
 export async function signOut(): Promise<void> {
-  // Two sessions exist: one for this application and one for the team domain.
-  // Clearing only the first leaves the next visit signed straight back in.
   await fetch("/cdn-cgi/access/logout").catch(() => {})
   const returnTo = encodeURIComponent(`${window.location.origin}/`)
   window.location.href = `https://${ACCESS_TEAM_DOMAIN}/cdn-cgi/access/logout?returnTo=${returnTo}`

--- a/src/admin/components/SiteMark.tsx
+++ b/src/admin/components/SiteMark.tsx
@@ -24,7 +24,6 @@ export function SiteMark({ onError }: { onError: (message: string) => void }) {
       const uploaded = await uploadImage(file)
       await api.admin.settings.setFavicon.mutate({ url: uploaded })
       setUrl(uploaded)
-      // The browser holds the old icon until the fixed path is fetched again.
       refreshTabIcon(uploaded)
     } catch (err) {
       onError(errorMessage(err))

--- a/src/admin/pages/PostEdit.tsx
+++ b/src/admin/pages/PostEdit.tsx
@@ -44,7 +44,6 @@ export function PostEdit() {
   const [busy, setBusy] = useState(false)
   const [uploadingCover, setUploadingCover] = useState(false)
 
-  // A ref: comparing against it must not itself schedule a render.
   const saved = useRef("")
 
   const titleField = useRef<HTMLTextAreaElement>(null)
@@ -90,8 +89,6 @@ export function PostEdit() {
         saved.current = snapshot
         setPost(updated)
         setError(null)
-        // Anything typed while the request was in flight leaves the draft
-        // ahead of the snapshot, and the autosave effect picks it up again.
         setSaveState(current => (current === "saving" ? "clean" : current))
       } catch (err) {
         setSaveState("failed")
@@ -200,7 +197,6 @@ export function PostEdit() {
 
   return (
     <div>
-      {/* Sticky: on a long post the publish control should never scroll away. */}
       <header className="sticky top-0 z-20 flex items-center justify-between gap-4 border-b border-border bg-background/85 px-8 py-3 backdrop-blur">
         <Link
           to="/admin/posts"
@@ -237,11 +233,6 @@ export function PostEdit() {
         </div>
       </header>
 
-      {/*
-        The same measure as the published article. A wider column here would
-        reflow every line on publish, which is the one thing a writing surface
-        built on the reader's stylesheet must not do.
-      */}
       <div className="mx-auto max-w-2xl px-6 pb-32 pt-12">
         {error && (
           <div className="mb-8">
@@ -318,8 +309,6 @@ export function PostEdit() {
   )
 }
 
-// Tiptap's focus command sets the selection but does not always move DOM
-// focus out of the field that had it.
 function focusEditor(editor: Editor | null): void {
   if (!editor) return
   editor.view.dom.focus()
@@ -429,7 +418,6 @@ const AutoTextarea = forwardRef<
       placeholder={placeholder}
       onChange={event => onChange(event.target.value)}
       onKeyDown={event => {
-        // A newline here would be dropped on render, so Enter moves on instead.
         if (event.key === "Enter") {
           event.preventDefault()
           onEnter?.()

--- a/src/admin/pages/PostsList.tsx
+++ b/src/admin/pages/PostsList.tsx
@@ -47,8 +47,6 @@ export function PostsList() {
     setCreating(true)
     setError(null)
     try {
-      // A placeholder slug keeps the draft addressable; the editor offers to
-      // match it to the title before the post is published.
       const slug = `untitled-${Date.now().toString(36)}`
       await api.admin.posts.create.mutate({ slug, title: "Untitled" })
       navigate(`/admin/posts/${slug}`)

--- a/src/api.ts
+++ b/src/api.ts
@@ -2,15 +2,10 @@ import { createTRPCClient, httpBatchLink } from "@trpc/client"
 import type { inferRouterOutputs } from "@trpc/server"
 import type { AppRouter } from "./worker/routers"
 
-/**
- * The reader's client. It carries no session handling, so a signed-out visitor
- * is never bounced anywhere.
- */
 export const publicApi = createTRPCClient<AppRouter>({
   links: [httpBatchLink({ url: "/trpc" })]
 })
 
-/** Derived from the router so a shape is never restated by hand on the client. */
 export type RouterOutputs = inferRouterOutputs<AppRouter>
 
 export function errorMessage(err: unknown): string {

--- a/src/editor/InsertMenu.tsx
+++ b/src/editor/InsertMenu.tsx
@@ -29,8 +29,6 @@ export function InsertMenu({
   const [open, setOpen] = useState(false)
   const fileInput = useRef<HTMLInputElement>(null)
 
-  // Moving to a different empty line should present a fresh plus rather than
-  // whatever state the last one was left in.
   const anchor = useTiptapState(({ editor }) => editor.state.selection.anchor)
   useEffect(() => setOpen(false), [anchor])
 

--- a/src/editor/PostEditor.tsx
+++ b/src/editor/PostEditor.tsx
@@ -27,8 +27,6 @@ export function PostEditor({
 }) {
   const [uploads, setUploads] = useState(0)
 
-  // The editor is built once, so its callbacks would otherwise close over the
-  // props from the first render.
   const handlers = useRef({ onChange, onError, onLeaveStart })
   handlers.current = { onChange, onError, onLeaveStart }
 
@@ -57,8 +55,6 @@ export function PostEditor({
       }),
       FileHandler.configure({
         allowedMimeTypes: IMAGE_TYPES,
-        // Without this both the file handler and the image extension act on a
-        // pasted screenshot, inserting it twice.
         consumePasteEvent: true,
         onDrop: (editor, files, position) => {
           files.forEach(file => void insertImage(editor, file, position))
@@ -74,8 +70,6 @@ export function PostEditor({
       handleKeyDown: (view, event) => {
         if (event.key !== "Backspace") return false
         const { empty, from } = view.state.selection
-        // Position 1 is inside the document's first block, so this is the
-        // caret sitting before the first character with nothing to delete.
         if (!empty || from !== 1) return false
         handlers.current.onLeaveStart?.()
         return true
@@ -92,8 +86,6 @@ export function PostEditor({
 
   return (
     <Tiptap editor={editor}>
-      {/* ProseMirror only focuses from a click on a text block, so the space
-          under a short document would otherwise be dead. */}
       <div
         className="min-h-96 cursor-text"
         onMouseDown={event => {

--- a/src/editor/SelectionMenu.tsx
+++ b/src/editor/SelectionMenu.tsx
@@ -24,8 +24,6 @@ export function SelectionMenu({ editor }: { editor: Editor }) {
   return (
     <BubbleMenu
       editor={editor}
-      // A selection inside a code block is code, not prose; offering bold there
-      // would produce a command the schema rejects.
       shouldShow={({ editor, from, to }) =>
         from !== to && !editor.isActive("codeBlock") && !editor.isActive("image")
       }

--- a/src/editor/controls.tsx
+++ b/src/editor/controls.tsx
@@ -17,8 +17,6 @@ export function ToolButton({
       title={label}
       aria-label={label}
       aria-pressed={active}
-      // The editor loses focus to a mousedown on the button, which collapses
-      // the selection the command is about to act on.
       onMouseDown={event => event.preventDefault()}
       onClick={onClick}
       className={`flex h-8 w-8 items-center justify-center rounded-md transition-colors ${
@@ -36,9 +34,5 @@ export function ToolDivider() {
   return <div className="mx-1 my-1.5 w-px self-stretch bg-border" />
 }
 
-/**
- * min-w keeps the panel from resizing when the link field replaces the button
- * row, which would otherwise move the buttons out from under the pointer.
- */
 export const floatingPanel =
   "flex min-w-[19rem] items-center rounded-lg border border-border bg-card p-1 shadow-lg shadow-black/50"

--- a/src/editor/document.ts
+++ b/src/editor/document.ts
@@ -1,6 +1,5 @@
 import type { JSONContent } from "@tiptap/core"
 
-// Posts are stored as a ProseMirror document, not HTML.
 export const EMPTY_DOCUMENT = '{"type":"doc","content":[]}'
 
 export function parseDocument(stored: string): JSONContent {
@@ -9,11 +8,7 @@ export function parseDocument(stored: string): JSONContent {
   try {
     const parsed: unknown = JSON.parse(stored)
     if (isDocument(parsed)) return parsed
-  } catch {
-    // Content predating the move to ProseMirror JSON is an HTML string. It
-    // parses as neither, so it is shown as a single paragraph rather than
-    // failing the page.
-  }
+  } catch {}
 
   return {
     type: "doc",

--- a/src/editor/extensions.ts
+++ b/src/editor/extensions.ts
@@ -2,9 +2,6 @@ import Image from "@tiptap/extension-image"
 import Typography from "@tiptap/extension-typography"
 import StarterKit from "@tiptap/starter-kit"
 
-// Both the editor and the static renderer take this exact list, or a post
-// renders differently from the way it was written. Editing behaviour belongs
-// in the editor. Headings start at h2 because the post title is the page's h1.
 export const contentExtensions = [
   StarterKit.configure({
     heading: { levels: [2, 3] },

--- a/src/editor/prose.css
+++ b/src/editor/prose.css
@@ -1,7 +1,3 @@
-/*
- * Article typography, applied to both the editor surface and the published
- * page. One stylesheet is the point: what is written is what is read.
- */
 .prose {
   color: var(--color-muted-foreground);
   font-size: 1.0625rem;
@@ -118,7 +114,6 @@
   width: 100%;
 }
 
-/* Three marks rather than a rule, so a section break reads as a pause. */
 .prose hr {
   border: none;
   margin: 2.5em 0;
@@ -132,9 +127,6 @@
   letter-spacing: 0.6em;
 }
 
-/* Editor-only. ProseMirror renders the document into .tiptap.
-   No min-height here: the wrapper owns it, so the space under a short
-   document belongs to an element that can act on a click. */
 .prose.tiptap {
   outline: none;
 }
@@ -155,7 +147,6 @@
   border-radius: 10px;
 }
 
-/* Dropping an image shows where it will land. */
 .prose.tiptap .ProseMirror-gapcursor::after {
   border-top-color: var(--color-foreground);
 }

--- a/src/index.css
+++ b/src/index.css
@@ -85,15 +85,6 @@
   --sidebar-ring: oklch(0.65 0.13 78);
 }
 
-/*
- * The shipped theme. Neutrals are a blue-tinted ink ramp at hue 265, the lone
- * brand colour a warm amber at hue 78.
- *
- * `brand` is deliberately not shadcn's `accent`, which is a neutral hover
- * surface for menu items and list rows. Amber there would tint every hover in
- * the app. The site spends `brand` on links and hovers; the admin leaves it to
- * focus rings, so the two read as different places.
- */
 .dark {
   --background: oklch(0.17 0.008 265);
   --foreground: oklch(0.94 0.004 265);
@@ -160,8 +151,6 @@
   color: var(--foreground);
 }
 
-/* The title and summary are the page's content; a ring around them while
-   typing reads as a form field rather than as writing. */
 .editorial:focus,
 .editorial:focus-visible {
   outline: none;

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -177,7 +177,6 @@ function RecentWriting() {
 export function Home() {
   return (
     <div className="mx-auto max-w-2xl px-6 py-28">
-      {/* Header */}
       <header>
         <p className="font-mono text-xs tracking-wide text-subtle-foreground">New York, NY</p>
         <h1 className="mt-3 text-4xl font-semibold tracking-tight text-foreground">
@@ -211,7 +210,6 @@ export function Home() {
         </nav>
       </header>
 
-      {/* Experience */}
       <Section title="Experience">
         <ol className="space-y-12">
           {experience.map(job => (
@@ -243,7 +241,6 @@ export function Home() {
         </ol>
       </Section>
 
-      {/* Projects */}
       <Section title="Projects">
         <ul>
           {projects.map(project => {
@@ -286,7 +283,6 @@ export function Home() {
 
       <RecentWriting />
 
-      {/* Footer */}
       <footer className="mt-16 border-t border-border pt-8 font-mono text-xs text-subtle-foreground">
         <OnRepeat />
         <div className="flex items-center justify-between">

--- a/src/worker/db/schema.ts
+++ b/src/worker/db/schema.ts
@@ -26,7 +26,6 @@ export const auditLog = sqliteTable(
   ]
 )
 
-/** Durable site configuration, unlike kv_cache which exists to be evicted. */
 export const settings = sqliteTable("settings", {
   key: text("key").primaryKey(),
   value: text("value").notNull(),
@@ -43,7 +42,6 @@ export const posts = sqliteTable("posts", {
   id: integer("id").primaryKey({ autoIncrement: true }),
   slug: text("slug").notNull().unique(),
   title: text("title").notNull(),
-  // A serialised ProseMirror document, not HTML. See src/editor/document.ts.
   content: text("content").notNull().default(EMPTY_DOCUMENT),
   excerpt: text("excerpt"),
   coverImage: text("cover_image"),

--- a/src/worker/index.ts
+++ b/src/worker/index.ts
@@ -53,15 +53,12 @@ export default {
       })
     }
 
-    // Falls through to the shipped file when no icon has been chosen.
     if (url.pathname === "/favicon.ico") {
       const chosen = await readSetting(drizzle(env.DB, { schema }), FAVICON_KEY)
       const chosenKey = chosen && mediaKeyFromPath(chosen)
       if (chosenKey) return serveMedia(env.MEDIA, chosenKey, request, FAVICON_CACHE_CONTROL)
     }
 
-    // Uploaded images are public, and are checked before the admin gate so a
-    // published post renders for readers who have no Access token.
     const mediaKey = mediaKeyFromPath(url.pathname)
     if (mediaKey) {
       if (request.method !== "GET" && request.method !== "HEAD") {

--- a/src/worker/media.ts
+++ b/src/worker/media.ts
@@ -2,10 +2,6 @@ import type { DrizzleD1Database } from "drizzle-orm/d1"
 import { writeAudit } from "./audit"
 import type * as schema from "./db/schema"
 
-/**
- * SVG is deliberately absent. It is served from the site's own origin, so an
- * SVG carrying a script tag would run as first-party code.
- */
 const EXTENSION_BY_TYPE = new Map([
   ["image/png", "png"],
   ["image/jpeg", "jpg"],
@@ -16,7 +12,6 @@ const EXTENSION_BY_TYPE = new Map([
 
 const MAX_UPLOAD_BYTES = 10 * 1024 * 1024
 
-/** Content-addressed, so the same image uploaded twice occupies one object. */
 const KEY_PATTERN = /^[0-9a-f]{64}\.[a-z0-9]+$/
 
 export const MEDIA_PREFIX = "/media/"
@@ -43,12 +38,10 @@ export async function serveMedia(
   const headers = new Headers()
   object.writeHttpMetadata(headers)
   headers.set("etag", object.httpEtag)
-  // The default key is a hash of the bytes, so that URL never changes.
   headers.set("cache-control", cacheControl)
   headers.set("x-content-type-options", "nosniff")
   headers.set("content-security-policy", "default-src 'none'; sandbox")
 
-  // A conditional hit returns metadata with no body.
   if (!("body" in object)) return new Response(null, { status: 304, headers })
 
   return new Response(object.body, { headers })

--- a/src/worker/routers/posts.ts
+++ b/src/worker/routers/posts.ts
@@ -10,11 +10,6 @@ const slugSchema = z
   .max(128)
   .regex(/^[a-z0-9]+(?:-[a-z0-9]+)*$/, "kebab-case slugs only")
 
-/**
- * Content arrives as a serialised ProseMirror document. Storing a string that
- * does not parse would break the public page at render time, which is far from
- * where the bad write happened, so it is rejected here.
- */
 const documentSchema = z.string().superRefine((value, ctx) => {
   let parsed: unknown
   try {
@@ -40,7 +35,6 @@ const postInput = z.object({
   coverImage: z.string().max(512).nullish()
 })
 
-/** The index does not need post bodies, which are the largest column by far. */
 const summaryColumns = {
   slug: posts.slug,
   title: posts.title,
@@ -113,10 +107,6 @@ export const adminPostsRouter = router({
       return updated
     }),
 
-  /**
-   * The slug is the post's public URL, so it may only move while the post has
-   * never been published.
-   */
   rename: protectedProcedure
     .input(z.object({ slug: slugSchema, nextSlug: slugSchema }))
     .mutation(async ({ ctx, input }) => {
@@ -163,8 +153,6 @@ export const adminPostsRouter = router({
         .update(posts)
         .set({
           status: input.status,
-          // First publish stamps the date; unpublishing and republishing keeps
-          // it, so a post does not jump to the top of the archive.
           ...(input.status === "published"
             ? { publishedAt: sql`coalesce(${posts.publishedAt}, ${timestamp})` }
             : {}),

--- a/src/worker/routers/settings.ts
+++ b/src/worker/routers/settings.ts
@@ -7,7 +7,6 @@ import { now, protectedProcedure, publicProcedure, router } from "../trpc"
 
 export const FAVICON_KEY = "favicon"
 
-/** A path produced by the media upload route, not an arbitrary URL. */
 const mediaPath = z.string().regex(/^\/media\/[0-9a-f]{64}\.[a-z0-9]+$/, "not an uploaded image")
 
 export async function readSetting(


### PR DESCRIPTION
Removes every comment across the stack. Whole-line matches only, so no string literal is touched.