### PR TITLE
fix: report every failure as a toast

### DIFF
--- a/src/admin/pages/Experiences.tsx
+++ b/src/admin/pages/Experiences.tsx
@@ -1,8 +1,8 @@
-import { useState } from "react"
+import { useEffect, useState } from "react"
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
 import { api, errorMessage, type RouterOutputs } from "../api"
 import { AdminPage } from "../components/AdminPage"
-import { Alert, AlertTitle } from "@/components/ui/alert"
+import { toast } from "sonner"
 import { Button } from "@/components/ui/button"
 import { Card } from "@/components/ui/card"
 import { Field, FieldLabel } from "@/components/ui/field"
@@ -39,16 +39,22 @@ export function Experiences() {
 
   const list = useQuery(api.admin.experiences.list.queryOptions())
 
+  const reportFailure = (cause: unknown) => toast.error(errorMessage(cause))
+
   const settled = {
+    onError: reportFailure,
     onSuccess: () => queryClient.invalidateQueries(api.admin.experiences.list.queryFilter())
   }
   const create = useMutation(api.admin.experiences.create.mutationOptions(settled))
   const update = useMutation(api.admin.experiences.update.mutationOptions(settled))
   const destroy = useMutation(api.admin.experiences.remove.mutationOptions(settled))
 
+  useEffect(() => {
+    if (list.error) toast.error(errorMessage(list.error))
+  }, [list.error])
+
   const items = list.data
   const saving = create.isPending || update.isPending
-  const error = list.error ?? create.error ?? update.error ?? destroy.error
 
   const save = async () => {
     if (!draft) return
@@ -77,12 +83,6 @@ export function Experiences() {
       action={<Button onClick={() => setDraft(empty)}>New experience</Button>}
     >
       <div className="flex flex-col gap-6">
-        {error && (
-          <Alert variant="destructive">
-            <AlertTitle>{errorMessage(error)}</AlertTitle>
-          </Alert>
-        )}
-
         {draft && (
           <Card className="gap-4 p-5">
             <div className="grid gap-4 sm:grid-cols-2">

--- a/src/admin/pages/PostsList.tsx
+++ b/src/admin/pages/PostsList.tsx
@@ -33,7 +33,6 @@ import {
 import { api, errorMessage, type RouterOutputs } from "../api"
 import { AdminPage } from "../components/AdminPage"
 import { useIsMobile } from "@/hooks/use-mobile"
-import { Alert, AlertTitle } from "@/components/ui/alert"
 import { Button } from "@/components/ui/button"
 import { Checkbox } from "@/components/ui/checkbox"
 import {
@@ -63,6 +62,7 @@ import {
   TableRow
 } from "@/components/ui/table"
 import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group"
+import { toast } from "sonner"
 
 type Post = RouterOutputs["admin"]["posts"]["list"][number]
 type StatusFilter = "all" | "draft" | "published"
@@ -101,8 +101,11 @@ export function PostsList() {
   const posts = useQuery(api.admin.posts.list.queryOptions())
   const listKey = api.admin.posts.list.queryKey()
 
+  const reportFailure = (cause: unknown) => toast.error(errorMessage(cause))
+
   const create = useMutation(
     api.admin.posts.create.mutationOptions({
+      onError: reportFailure,
       onSuccess: post => {
         void queryClient.invalidateQueries(api.admin.posts.list.queryFilter())
         if (post) navigate(`/admin/posts/${post.slug}`)
@@ -119,8 +122,9 @@ export function PostsList() {
       if (previous) queryClient.setQueryData(listKey, apply(previous, variables))
       return { previous }
     },
-    onError: (_error: unknown, _variables: TVariables, context?: { previous?: Post[] }) => {
+    onError: (cause: unknown, _variables: TVariables, context?: { previous?: Post[] }) => {
       if (context?.previous) queryClient.setQueryData(listKey, context.previous)
+      reportFailure(cause)
     },
     onSettled: () => queryClient.invalidateQueries(api.admin.posts.list.queryFilter())
   })
@@ -142,8 +146,6 @@ export function PostsList() {
       )
     )
   )
-
-  const error = posts.error ?? create.error ?? setStatus.error ?? remove.error
 
   const columns = useMemo(
     () => [
@@ -380,12 +382,6 @@ export function PostsList() {
 
   return (
     <AdminPage title="Posts" action={newPost} header={selectionHeader} toolbar={toolbar}>
-      {error && (
-        <Alert variant="destructive" className="mb-4">
-          <AlertTitle>{errorMessage(error)}</AlertTitle>
-        </Alert>
-      )}
-
       {posts.isPending ? (
         <PostRowsSkeleton />
       ) : (posts.data?.length ?? 0) === 0 ? (

--- a/src/admin/pages/Projects.tsx
+++ b/src/admin/pages/Projects.tsx
@@ -1,8 +1,8 @@
-import { useState } from "react"
+import { useEffect, useState } from "react"
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
 import { api, errorMessage, type RouterOutputs } from "../api"
 import { AdminPage } from "../components/AdminPage"
-import { Alert, AlertTitle } from "@/components/ui/alert"
+import { toast } from "sonner"
 import { Button } from "@/components/ui/button"
 import { Card } from "@/components/ui/card"
 import { Field, FieldLabel } from "@/components/ui/field"
@@ -35,16 +35,22 @@ export function Projects() {
 
   const list = useQuery(api.admin.projects.list.queryOptions())
 
+  const reportFailure = (cause: unknown) => toast.error(errorMessage(cause))
+
   const settled = {
+    onError: reportFailure,
     onSuccess: () => queryClient.invalidateQueries(api.admin.projects.list.queryFilter())
   }
   const create = useMutation(api.admin.projects.create.mutationOptions(settled))
   const update = useMutation(api.admin.projects.update.mutationOptions(settled))
   const destroy = useMutation(api.admin.projects.remove.mutationOptions(settled))
 
+  useEffect(() => {
+    if (list.error) toast.error(errorMessage(list.error))
+  }, [list.error])
+
   const items = list.data
   const saving = create.isPending || update.isPending
-  const error = list.error ?? create.error ?? update.error ?? destroy.error
 
   const save = async () => {
     if (!draft) return
@@ -71,12 +77,6 @@ export function Projects() {
       action={<Button onClick={() => setDraft(empty)}>New project</Button>}
     >
       <div className="flex flex-col gap-6">
-        {error && (
-          <Alert variant="destructive">
-            <AlertTitle>{errorMessage(error)}</AlertTitle>
-          </Alert>
-        )}
-
         {draft && (
           <Card className="gap-4 p-5">
             <Field>

--- a/src/worker/trpc.ts
+++ b/src/worker/trpc.ts
@@ -27,7 +27,14 @@ export function createContext({ req, env, executionCtx, identity }: ContextOptio
 
 export type Context = ReturnType<typeof createContext>
 
-const t = initTRPC.context<Context>().create()
+const t = initTRPC.context<Context>().create({
+  errorFormatter({ shape, error }) {
+    if (error.code !== "INTERNAL_SERVER_ERROR") return shape
+
+    console.error("trpc", error.cause ?? error)
+    return { ...shape, message: "Something went wrong. The details are in the logs." }
+  }
+})
 
 export const router = t.router
 export const publicProcedure = t.procedure


### PR DESCRIPTION
Moves the remaining inline error banners in the admin onto sonner.