### PR TITLE
ci: fail the build on comments

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,7 @@ jobs:
       - run: pnpm run db:generate
       - run: git add -N migrations && git diff --exit-code migrations
       - run: pnpm run lint
+      - run: pnpm run check:comments
       - run: pnpm run format
       - run: pnpm run check
       - run: pnpm test

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "deploy": "pnpm run build && pnpm run db:migrate && wrangler deploy",
     "db:generate": "drizzle-kit generate",
     "db:migrate:local": "wrangler d1 migrations apply DB --local",
-    "db:migrate": "wrangler d1 migrations apply DB --remote"
+    "db:migrate": "wrangler d1 migrations apply DB --remote",
+    "check:comments": "node scripts/check-comments.mjs"
   },
   "dependencies": {
     "@ariakit/react": "^0.4.36",

--- a/scripts/check-comments.mjs
+++ b/scripts/check-comments.mjs
@@ -1,0 +1,33 @@
+import { readdirSync, readFileSync, statSync } from "node:fs"
+import { join } from "node:path"
+
+const ROOTS = ["src/admin", "src/editor", "src/worker", "src/pages", "src/lib", "src/hooks"]
+const ALLOWED = ["eslint", "@ts-", "oxlint", "biome", "prettier", "use client", "use strict"]
+
+const walk = dir =>
+  readdirSync(dir).flatMap(entry => {
+    const path = join(dir, entry)
+    return statSync(path).isDirectory() ? walk(path) : [path]
+  })
+
+const offences = []
+
+for (const root of ROOTS) {
+  for (const path of walk(root).filter(p => /\.tsx?$/.test(p))) {
+    readFileSync(path, "utf8")
+      .split("\n")
+      .forEach((line, index) => {
+        const text = line.trim()
+        const isComment = text.startsWith("//") || text.startsWith("/*") || text.startsWith("* ")
+        if (isComment && !ALLOWED.some(allowed => text.includes(allowed))) {
+          offences.push(`${path}:${index + 1}: ${text.slice(0, 72)}`)
+        }
+      })
+  }
+}
+
+if (offences.length) {
+  console.error(`Comments are not this repo's habit. Found ${offences.length}:\n`)
+  console.error(offences.join("\n"))
+  process.exit(1)
+}


### PR DESCRIPTION
Makes the no-comments rule enforceable rather than remembered.